### PR TITLE
Exposed RandNonce function to generate a random nonce function

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -48,11 +48,12 @@ func BenchmarkCSP(b *testing.B) {
 		base-uri 'none';
 		report-uri https://your-report-collector.example.com/;`,
 
-		ByteAmount: 16,
+		ByteSize: 16,
 	}
 
 	handler := csp.Middleware()(testHandler)
 
+	b.ReportAllocs()
 	b.ResetTimer()
 
 	b.RunParallel(func(pb *testing.PB) {

--- a/csp_test.go
+++ b/csp_test.go
@@ -21,8 +21,8 @@ func TestCSPNonce(t *testing.T) {
 	for byteAmount := 1; byteAmount < 20; byteAmount++ {
 		t.Run(fmt.Sprintf("TestCSPNonceByteAmount%d", byteAmount), func(t *testing.T) {
 			s := secure.CSP{
-				Value:      "default-src 'self' {{ . }}; script-src 'strict-dynamic' {{ . }}",
-				ByteAmount: byteAmount,
+				Value:    "default-src 'self' {{ . }}; script-src 'strict-dynamic' {{ . }}",
+				ByteSize: byteAmount,
 			}
 
 			res := httptest.NewRecorder()
@@ -93,8 +93,8 @@ func TestCSPWrongTemplate(t *testing.T) {
 	}()
 
 	csp := secure.CSP{
-		Value:      "{{ .Name }}",
-		ByteAmount: 32,
+		Value:    "{{ .Name }}",
+		ByteSize: 32,
 	}
 
 	res := httptest.NewRecorder()
@@ -112,8 +112,8 @@ func TestCSPNilHandler(t *testing.T) {
 	}()
 
 	csp := secure.CSP{
-		Value:      "script-src 'none';",
-		ByteAmount: 32,
+		Value:    "script-src 'none';",
+		ByteSize: 32,
 	}
 
 	res := httptest.NewRecorder()

--- a/example_test.go
+++ b/example_test.go
@@ -59,8 +59,8 @@ func ExampleCSP_Middleware() {
 	mux := http.NewServeMux()
 
 	csp := &secure.CSP{
-		Value:      `object-src 'none'; script-src {{ . }} 'strict-dynamic'; base-uri 'self'; report-uri https://appointy.com/_csp;`,
-		ByteAmount: 8,
+		Value:    `object-src 'none'; script-src {{ . }} 'strict-dynamic'; base-uri 'self'; report-uri https://appointy.com/_csp;`,
+		ByteSize: 8,
 	}
 
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
1. Changed RandNonce from []byte to io.WriteByte

TODO:

Change bytes.Buffer usage to string.Builder when Go 1.10 hits